### PR TITLE
Update circleci config generator to include the final step

### DIFF
--- a/scripts/circleci_maker.rb
+++ b/scripts/circleci_maker.rb
@@ -5,6 +5,19 @@ require 'json'
 dokken_instances = JSON.load(ARGF.read)
 
 circle_config = {
+  'jobs' => {
+    'final' => {
+      'docker' => [
+        'image' => 'bash:latest',
+      ],
+      'steps' => [
+        'run' => {
+          'name' => 'Finish cooking',
+          'command' => 'echo "Finished cooking"',
+        },
+      ],
+    },
+  },
   'lint_and_unit' => %w(
     delivery
     danger
@@ -44,6 +57,8 @@ circle_config = {
   },
 }
 
+final = { 'requires' => [] }
+
 # Handle docker instances
 dokken_instances.each do |i|
   instance_name = i['instance']
@@ -52,14 +67,25 @@ dokken_instances.each do |i|
     'suite' => instance_name,
     'requires' => '*lint_and_unit',
   })
+
+  # Add instance names to final requires to force all jobs to pass
+  final['requires'].append(i['instance'])
 end
+
+# add final workflow
+circle_config['workflows']['kitchen']['jobs'].append('final' => final)
+
 yaml_config = circle_config.to_yaml
+
 # The & is not part of the standard, so we have to hack it in
+# A bunch of yaml hacking as the to_yaml isn't perfect
 yaml_config.sub!('lint_and_unit:', 'lint_and_unit: &lint_and_unit')
 yaml_config.gsub!('"*lint_and_unit"', '*lint_and_unit')
 yaml_config.gsub!('- ', '  - ')
+yaml_config.gsub!('          - ', '            - ') # for final requires...
 yaml_config.gsub!('suite:', '  suite:')
 yaml_config.gsub!('name:', '  name:')
 yaml_config.gsub!('requires:', '  requires:')
 yaml_config.gsub!('context:', '  context:')
+yaml_config.gsub!('command:', '  command:')
 puts(yaml_config)


### PR DESCRIPTION
# Description

Adds a final step in the circle jobs that requires all previous jobs succeed. This in tandem with requiring that step pass via github branch protection will help us keep repos green!

Checkout the linked issue for more details.

## Issues Resolved

closes https://github.com/sous-chefs/meta/issues/128

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
