### PR TITLE
add .editorconfig file

### DIFF
--- a/standardfiles/cookbook/.editorconfig
+++ b/standardfiles/cookbook/.editorconfig
@@ -1,0 +1,11 @@
+#https://EditorConfig.org
+# top-most EditorConfig file
+root=true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true


### PR DESCRIPTION
Signed-off-by: Corey Hemminger <hemminger@hotmail.com>

# Description

Adds opensource standard IDE settings based on https://editorconfig.org/

## Issues Resolved

Ensures code repo standards are used by IDE's supporting .editorconfig without users having to change default or personalized settings for other work.