### PR TITLE
Update Dangerfile to check for release labels

### DIFF
--- a/standardfiles/cookbook/Dangerfile
+++ b/standardfiles/cookbook/Dangerfile
@@ -36,6 +36,11 @@ if !git.modified_files.include?('CHANGELOG.md') && code_changes?
   failure 'Please include a CHANGELOG entry.'
 end
 
+# Require Major Minor Patch version labels
+unless github.pr_labels.grep /minor|major|patch/i
+  failure 'Please add a release label to this pull request'
+end
+
 # A sanity check for tests.
 if git.lines_of_code > 5 && code_changes? && !test_changes?
   warn 'This Pull Request is probably missing tests.'


### PR DESCRIPTION
# Description

Update Dangerfile to check for release labels
This will enable us to release based on one of the attached labels every pull request

## Issues Resolved

None

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
