### PR TITLE
Remove the GitHub lock file

### DIFF
--- a/standardfiles/cookbook/.github/lock.yml
+++ b/standardfiles/cookbook/.github/lock.yml
@@ -1,8 +1,0 @@
----
-daysUntilLock: 365
-exemptLabels: []
-lockLabel: false
-lockComment: >
-  This thread has been automatically locked since there has not been
-  any recent activity after it was closed. Please open a new issue for
-  related bugs.


### PR DESCRIPTION
I don't think historically we've had enough issues in the Chef community
the warrant this kind of tactic. The lock bots are very noisy and
encourage people to stop following repos. We want all the eyes we can get
so let's do our best to keep those eyes.

Signed-off-by: Tim Smith <tsmith@chef.io>