### PR TITLE
Add .vscode dir to auto install extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+      "chef-software.chef",
+      "rebornix.ruby"
+  ]
+}


### PR DESCRIPTION
The majority (by a long shot) of Chef Infra users are using vscode so we
should make sure they have the necessary extensions to be successful
developing these cookbooks.

Signed-off-by: Tim Smith <tsmith@chef.io>