### PR TITLE
force upload of changelog

### DIFF
--- a/standardfiles/cookbook/chefignore
+++ b/standardfiles/cookbook/chefignore
@@ -95,7 +95,7 @@ Policyfile.lock.json
 
 # Documentation #
 #############
-CHANGELOG*
+# CHANGELOG*
 CONTRIBUTING*
 TESTING*
 CODE_OF_CONDUCT*


### PR DESCRIPTION
# Description

Commented out changelog line to force `knife supermarket share` command to upload the changelog to the supermarket

## Issues Resolved

NA

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
