### PR TITLE
Feat: Add label for Accepted Hacktoberfest PR

### DIFF
--- a/labels/cookbook/hacktoberfest-accepted.json
+++ b/labels/cookbook/hacktoberfest-accepted.json
@@ -1,0 +1,6 @@
+{
+    "name": "hacktoberfest-accepted",
+    "color": "#F3CB3D",
+    "description": "PR has been accepted for hacktoberfest 2020. Waiting on merge"
+}
+  


### PR DESCRIPTION
# Description
Adds a `hacktoberfest-accepted` label. This makes it so any valid PR's in October count towards a participants hacktoberfest quota without the PR having to be merged. 

## Issues Resolved

None

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
