### PR TITLE
Disable start checks for .kitchen ERB files

### DIFF
--- a/standardfiles/cookbook/.yamllint
+++ b/standardfiles/cookbook/.yamllint
@@ -4,3 +4,4 @@ rules:
   line-length:
     max: 256
     level: warning
+  document-start: disable


### PR DESCRIPTION
For .kitchen.yml files that include Ruby erb sytax at the top the document-start check fails. 
See https://github.com/sous-chefs/mysql/runs/1191136288?check_suite_focus=true

# Description

Disable checks in yamllint 

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
