### PR TITLE
Allow spaces inside braces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@master
+        uses: actions/checkout@main
       - name: Run Chef Delivery
-        uses: actionshub/chef-delivery@master
+        uses: actionshub/chef-delivery@main
         env:
           CHEF_LICENSE: accept-no-persist
 
@@ -21,14 +21,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@master
+        uses: actions/checkout@main
       - name: Run yaml Lint
-        uses: actionshub/yamllint@master
+        uses: actionshub/yamllint@main
 
   mdl:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@master
+        uses: actions/checkout@main
       - name: Run Markdown Lint
-        uses: actionshub/markdownlint@master
+        uses: actionshub/markdownlint@main

--- a/standardfiles/cookbook/.github/workflows/md-links.yml
+++ b/standardfiles/cookbook/.github/workflows/md-links.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@master
+        uses: actions/checkout@main
       - name: markdown-link-check
         uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:

--- a/standardfiles/cookbook/.github/workflows/stale.yml
+++ b/standardfiles/cookbook/.github/workflows/stale.yml
@@ -2,14 +2,11 @@
 name: Mark stale issues and pull requests
 
 "on":
-  schedule:
-    - cron: "0 0 * * *"
+  schedule: [cron: "0 0 * * *"]
 
 jobs:
   stale:
-
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/stale@v3
         with:

--- a/standardfiles/cookbook/.yamllint
+++ b/standardfiles/cookbook/.yamllint
@@ -5,3 +5,9 @@ rules:
     max: 256
     level: warning
   document-start: disable
+  braces:
+    forbid: false
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1

--- a/standardfiles/ide/.github/workflows/ci.yml
+++ b/standardfiles/ide/.github/workflows/ci.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@master
+        uses: actions/checkout@main
       - name: Run yaml Lint
-        uses: actionshub/yamllint@master
+        uses: actionshub/yamllint@main
 
   mdl:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@master
+        uses: actions/checkout@main
       - name: Run Markdown Lint
-        uses: actionshub/markdownlint@master
+        uses: actionshub/markdownlint@main

--- a/standardfiles/terraform/.github/workflows/ci.yml
+++ b/standardfiles/terraform/.github/workflows/ci.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@master
+        uses: actions/checkout@main
       - name: Run yaml Lint
-        uses: actionshub/yamllint@master
+        uses: actionshub/yamllint@main
 
   mdl:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@master
+        uses: actions/checkout@main
       - name: Run Markdown Lint
-        uses: actionshub/markdownlint@master
+        uses: actionshub/markdownlint@main

--- a/standardfiles/terraform/.github/workflows/terraform-lint.yml
+++ b/standardfiles/terraform/.github/workflows/terraform-lint.yml
@@ -8,6 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@master
+        uses: actions/checkout@main
       - name: Lint Terraform
-        uses: actionshub/terraform-lint@master
+        uses: actionshub/terraform-lint@main


### PR DESCRIPTION
This allows us to write yaml like this:
```yaml
transport: { name: dokken }
```
instead of being forced to write:
```yaml
transport: {name: dokken}
```
The latter looks more readable
