### PR TITLE
Stop using remote delivery file

### DIFF
--- a/standardfiles/cookbook/.delivery/project.toml
+++ b/standardfiles/cookbook/.delivery/project.toml
@@ -1,1 +1,9 @@
-remote_file = "https://raw.githubusercontent.com/chef-cookbooks/community_cookbook_tools/master/delivery/project.toml"
+[local_phases]
+unit = "rspec spec/"
+lint = 'cookstyle --display-cop-names --extra-details'
+syntax = "echo skipping"
+provision = "echo skipping"
+deploy = "echo skipping"
+smoke = "echo skipping"
+functional = "echo skipping"
+cleanup = "echo skipping"


### PR DESCRIPTION
# Description

Stop using remote delivery file

## Issues Resolved

Current Chef cannot pull remote delivery files anymore.

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
