### PR TITLE
Update chefignore to match all Kitchen config files

### DIFF
--- a/standardfiles/cookbook/chefignore
+++ b/standardfiles/cookbook/chefignore
@@ -61,7 +61,7 @@ Dangerfile
 examples/*
 features/*
 Guardfile
-kitchen.yml*
+kitchen*.yml
 mlc_config.json
 Procfile
 Rakefile


### PR DESCRIPTION
# Description

As per https://github.com/sous-chefs/logrotate/pull/167 we aren't matching all the kitchen config files in `chefignore`.

## Issues Resolved

https://github.com/sous-chefs/logrotate/pull/167

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
