### PR TITLE
Update test branch from `master` to `main` in ide standardfiles

### DIFF
--- a/standardfiles/ide/.github/workflows/ci.yml
+++ b/standardfiles/ide/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ name: ci
 "on":
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   yamllint:


### PR DESCRIPTION
# Description

I verified we set this topic on two repos, and both were switched to using `main` as the default branch. This breaks testing in both of these repos

- https://github.com/sous-chefs/sublimechef
- https://github.com/sous-chefs/language-chef

## Issues Resolved

Will prevent these PRS https://github.com/sous-chefs/sublimechef/pull/52

## Check List

- [x] There is no changelog in this repo
- [x] New functionality is testing.
- [x] New functionality has been documented in the README if applicable.
