### PR TITLE
Fix gaurav-nelson/github-action-markdown-link-check

### DIFF
--- a/standardfiles/cookbook/.github/workflows/md-links.yml
+++ b/standardfiles/cookbook/.github/workflows/md-links.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: markdown-link-check
-        uses: gaurav-nelson/github-action-markdown-link-check@v1.0.13
+        uses: gaurav-nelson/github-action-markdown-link-check@1.0.13
         with:
           use-verbose-mode: "yes"
           folder-path: "documentation"


### PR DESCRIPTION
The version doesn't have a leading v in the tags

Signed-off-by: Dan Webb <dan.webb@damacus.io>
