### PR TITLE
Use one name per markdown lint rule

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,4 +1,4 @@
 config:
   ul-indent: false # MD007
   line-length: false # MD013
-  no-duplicate-heading/no-duplicate-header: false # MD024
+  no-duplicate-heading: false # MD024

--- a/standardfiles/cookbook/.markdownlint-cli2.yaml
+++ b/standardfiles/cookbook/.markdownlint-cli2.yaml
@@ -1,4 +1,4 @@
 config:
   ul-indent: false # MD007
   line-length: false # MD013
-  no-duplicate-heading/no-duplicate-header: false # MD024
+  no-duplicate-heading: false # MD024

--- a/standardfiles/ide/.markdownlint-cli2.yaml
+++ b/standardfiles/ide/.markdownlint-cli2.yaml
@@ -1,4 +1,4 @@
 config:
   ul-indent: false # MD007
   line-length: false # MD013
-  no-duplicate-heading/no-duplicate-header: false # MD024
+  no-duplicate-heading: false # MD024

--- a/standardfiles/terraform/.markdownlint-cli2.yaml
+++ b/standardfiles/terraform/.markdownlint-cli2.yaml
@@ -1,4 +1,4 @@
 config:
   ul-indent: false # MD007
   line-length: false # MD013
-  no-duplicate-heading/no-duplicate-header: false # MD024
+  no-duplicate-heading: false # MD024


### PR DESCRIPTION
Mixing more than one does not work per documentation.

Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
