### PR TITLE
Ignore   reference-links-images: false # MD052

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -2,3 +2,4 @@ config:
   ul-indent: false # MD007
   line-length: false # MD013
   no-duplicate-heading/no-duplicate-header: false # MD024
+  reference-links-images: false # MD052

--- a/standardfiles/cookbook/.markdownlint-cli2.yaml
+++ b/standardfiles/cookbook/.markdownlint-cli2.yaml
@@ -2,3 +2,4 @@ config:
   ul-indent: false # MD007
   line-length: false # MD013
   no-duplicate-heading/no-duplicate-header: false # MD024
+  reference-links-images: false # MD052

--- a/standardfiles/ide/.markdownlint-cli2.yaml
+++ b/standardfiles/ide/.markdownlint-cli2.yaml
@@ -2,3 +2,4 @@ config:
   ul-indent: false # MD007
   line-length: false # MD013
   no-duplicate-heading/no-duplicate-header: false # MD024
+  reference-links-images: false # MD052

--- a/standardfiles/terraform/.markdownlint-cli2.yaml
+++ b/standardfiles/terraform/.markdownlint-cli2.yaml
@@ -2,3 +2,4 @@ config:
   ul-indent: false # MD007
   line-length: false # MD013
   no-duplicate-heading/no-duplicate-header: false # MD024
+  reference-links-images: false # MD052


### PR DESCRIPTION
We get false positives from node attributes in markdown files
