### PR TITLE
chore: remove eol platform from kitchen.global.yml

### DIFF
--- a/standardfiles/cookbook/kitchen.global.yml
+++ b/standardfiles/cookbook/kitchen.global.yml
@@ -28,7 +28,6 @@ platforms:
   - name: oraclelinux-9
   - name: rockylinux-8
   - name: rockylinux-9
-  - name: ubuntu-18.04
   - name: ubuntu-20.04
   - name: ubuntu-22.04
   - name: ubuntu-24.04


### PR DESCRIPTION
# Description

removing EOL ubuntu 18.04.

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
