### PR TITLE
Remove EOL CentOS-Stream-8

### DIFF
--- a/standardfiles/cookbook/kitchen.dokken.yml
+++ b/standardfiles/cookbook/kitchen.dokken.yml
@@ -22,11 +22,6 @@ platforms:
       image: dokken/amazonlinux-2023
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: centos-stream-8
-    driver:
-      image: dokken/centos-stream-8
-      pid_one_command: /usr/lib/systemd/systemd
-
   - name: centos-stream-9
     driver:
       image: dokken/centos-stream-9

--- a/standardfiles/cookbook/kitchen.global.yml
+++ b/standardfiles/cookbook/kitchen.global.yml
@@ -18,7 +18,6 @@ platforms:
   - name: almalinux-8
   - name: almalinux-9
   - name: amazonlinux-2023
-  - name: centos-stream-8
   - name: centos-stream-9
   - name: debian-11
   - name: debian-12


### PR DESCRIPTION
# Description

Removes EOL CentOS-Stream-8 platforms from standard cookbook files

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
