### PR TITLE
Migrate Renovate config from base to recommended

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
-  "packageRules": [{
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
       "groupName": "Actions",
-      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "matchUpdateTypes": ["minor", "patch", "pin"],
       "automerge": true,
       "addLabels": ["Release: Patch", "Skip: Announcements"]
     },

--- a/standardfiles/cookbook/renovate.json
+++ b/standardfiles/cookbook/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:recommended"],
   "packageRules": [
     {
       "groupName": "Actions",


### PR DESCRIPTION
- config:base have been replaced by recommended
  https://docs.renovatebot.com/presets-config/#configrecommended

Signed-off-by: Dan Webb <dan.webb@damacus.io>
