### PR TITLE
Switch default product to cinc and refresh test platforms

### DIFF
--- a/standardfiles/cookbook/kitchen.dokken.yml
+++ b/standardfiles/cookbook/kitchen.dokken.yml
@@ -1,10 +1,12 @@
 driver:
   name: dokken
   privileged: true
-  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+  chef_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
 
 transport: { name: dokken }
-provisioner: { name: dokken }
+provisioner:
+  name: dokken
+  product_name: cinc
 
 platforms:
   - name: almalinux-8
@@ -67,6 +69,11 @@ platforms:
       image: dokken/oraclelinux-9
       pid_one_command: /usr/lib/systemd/systemd
 
+  - name: oraclelinux-10
+    driver:
+      image: dokken/oraclelinux-10
+      pid_one_command: /usr/lib/systemd/systemd
+
   - name: rockylinux-8
     driver:
       image: dokken/rockylinux-8
@@ -96,3 +103,8 @@ platforms:
     driver:
       image: dokken/ubuntu-24.04
       pid_one_command: /bin/systemd
+
+  - name: ubuntu-26.04
+    driver:
+      image: dokken/ubuntu-26.04
+      pid_one_command: /usr/lib/systemd/systemd

--- a/standardfiles/cookbook/kitchen.global.yml
+++ b/standardfiles/cookbook/kitchen.global.yml
@@ -1,7 +1,6 @@
 ---
 provisioner:
-  name: chef_infra
-  product_name: chef
+  name: cinc_infra
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   channel: stable
   install_strategy: once
@@ -17,16 +16,21 @@ verifier:
 platforms:
   - name: almalinux-8
   - name: almalinux-9
+  - name: almalinux-10
   - name: amazonlinux-2023
   - name: centos-stream-9
-  - name: debian-11
+  - name: centos-stream-10
   - name: debian-12
+  - name: debian-13
   - name: fedora-latest
   - name: opensuse-leap-15
   - name: oraclelinux-8
   - name: oraclelinux-9
+  - name: oraclelinux-10
   - name: rockylinux-8
   - name: rockylinux-9
+  - name: rockylinux-10
   - name: ubuntu-20.04
   - name: ubuntu-22.04
   - name: ubuntu-24.04
+  - name: ubuntu-26.04


### PR DESCRIPTION
Progress Chef no longer publishes free omnibus packages of Chef Infra
Client on the stable channel, so installs default to cinc, the
community-maintained, fully open source build of Chef Infra. Point our
standard kitchen configs at cinc instead of chef so test converges keep
working without commercial licensing.

- Use the cinc_infra provisioner (global) and product_name: cinc (dokken)
  instead of chef / chef_infra
- Default chef_version to latest
- Drop debian-11
- Add almalinux-10, centos-stream-10, debian-13, oraclelinux-10, rockylinux-10, and ubuntu-26.04

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves.

## Issues Resolved

List any existing issues this PR resolves.

## Check List

- [ ] All commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
  - **Required**: This triggers our automated CHANGELOG and release pipeline (release-please)
  - **Without conventional commits, your changes cannot be released**
  - Examples: `fix: resolve bug in resource`, `feat: add new property`, `docs: update README`
- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable

## ⚠️ Important: Automated Release Workflow

**DO NOT manually edit these files:**

- ❌ `metadata.rb` version - Managed by release-please
- ❌ `CHANGELOG.md` - Auto-generated from conventional commits
- ❌ Version tags - Created automatically on release

**The release process:**

1. Merge PR with conventional commits → release-please creates a release PR
2. Merge release PR → automatic version bump, CHANGELOG update, and Supermarket publish
3. Your changes are released! 🎉

**Need help?** See [Conventional Commits guide](https://www.conventionalcommits.org/)
